### PR TITLE
Fix resume link behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     <div class="container">
         <nav>
             <ul>
-                <li id="resume"><a href="https://bit.ly/SujayAug24CV">/resume</a></li>
+                <li id="resume"><a href="https://bit.ly/SujayAug24CV" target="_blank" rel="noopener noreferrer">/resume</a></li>
             </ul>
         </nav>
 


### PR DESCRIPTION
## Summary
- open `/resume` link in a new tab to keep user on the page

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68447a58cb408322b137976a20366a01