### PR TITLE
fix: respect safe-area insets so nav clears notches and status bars

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en" data-theme="dark">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
   <title>Sujay Kumar Suman — Software Engineer</title>
   <meta name="description" content="Sujay Kumar Suman — software engineer building Go services, Kubernetes-native controllers, and platforms that stay clear under load." />
   <link rel="icon" href="/assets/brand/favicon.svg" type="image/svg+xml" />

--- a/styles.css
+++ b/styles.css
@@ -116,7 +116,7 @@ a { color: inherit; text-decoration: none; }
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 18px 32px;
+  padding: calc(env(safe-area-inset-top, 0px) + 18px) max(32px, env(safe-area-inset-right, 0px)) 18px max(32px, env(safe-area-inset-left, 0px));
   transition: all 0.3s ease;
 }
 .nav.scrolled {
@@ -124,7 +124,7 @@ a { color: inherit; text-decoration: none; }
   backdrop-filter: blur(18px);
   -webkit-backdrop-filter: blur(18px);
   border-bottom: 1px solid var(--line-soft);
-  padding: 12px 32px;
+  padding: calc(env(safe-area-inset-top, 0px) + 12px) max(32px, env(safe-area-inset-right, 0px)) 12px max(32px, env(safe-area-inset-left, 0px));
 }
 .nav-brand {
   display: flex; align-items: center; gap: 10px;
@@ -1712,8 +1712,8 @@ a { color: inherit; text-decoration: none; }
 /* ===================== MOBILE RESPONSIVE ===================== */
 @media (max-width: 880px) {
   /* Nav — tighter spacing, smaller labels */
-  .nav { padding: 14px 18px; }
-  .nav.scrolled { padding: 10px 18px; }
+  .nav { padding: calc(env(safe-area-inset-top, 0px) + 14px) max(18px, env(safe-area-inset-right, 0px)) 14px max(18px, env(safe-area-inset-left, 0px)); }
+  .nav.scrolled { padding: calc(env(safe-area-inset-top, 0px) + 10px) max(18px, env(safe-area-inset-right, 0px)) 10px max(18px, env(safe-area-inset-left, 0px)); }
   .nav-brand { font-size: 16px; gap: 8px; }
   .nav-links { gap: 2px; font-size: 12px; }
   .nav-links a { padding: 6px 8px; }
@@ -1721,8 +1721,8 @@ a { color: inherit; text-decoration: none; }
 }
 @media (max-width: 640px) {
   /* Nav — wrap into 2 rows: brand + theme on row 1, nav-links on row 2 */
-  .nav { padding: 10px 16px; flex-wrap: wrap; row-gap: 6px; }
-  .nav.scrolled { padding: 8px 16px; }
+  .nav { padding: calc(env(safe-area-inset-top, 0px) + 10px) max(16px, env(safe-area-inset-right, 0px)) 10px max(16px, env(safe-area-inset-left, 0px)); flex-wrap: wrap; row-gap: 6px; }
+  .nav.scrolled { padding: calc(env(safe-area-inset-top, 0px) + 8px) max(16px, env(safe-area-inset-right, 0px)) 8px max(16px, env(safe-area-inset-left, 0px)); }
   .nav-brand { order: 1; gap: 6px; }
   .theme-toggle { order: 2; width: 34px; height: 34px; font-size: 14px; }
   .nav-links {


### PR DESCRIPTION
## Summary
On edge-to-edge phones (Xiaomi/Mi Browser, recent Chrome Android with "draw behind system bars" enabled, iOS Safari on notched iPhones), the fixed nav at `top: 0` was sliding behind the status bar — only the bottom half of the brand and theme-toggle were visible:

![phone screenshot showing nav clipped under the status bar](https://github.com/sujaykumarsuman/sujaykumarsuman.github.io/issues)

- Opt into edge-to-edge explicitly with `viewport-fit=cover` so `env(safe-area-inset-*)` returns real values on supporting browsers.
- Pad the nav by `env(safe-area-inset-top)` (and `-right` / `-left`) at every breakpoint — base, ≤880px, ≤640px — so the brand row sits below the system UI on those devices.
- The pattern is `padding-top: calc(env(safe-area-inset-top, 0px) + Npx)`, so on phones and desktops without a safe-area inset `env()` returns `0px` and rendering is unchanged from main.

## Test plan
- [ ] Phone with notch / edge-to-edge mode: brand and theme toggle are no longer clipped under the status bar
- [ ] Desktop browser: nav padding looks identical to current main (no extra whitespace)
- [ ] Landscape on notched phone: nav sides clear the notch (left/right insets honored)
- [ ] Theme toggle and nav-link clicks still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)