### PR TITLE
fix: floor mobile nav top padding and swap hero CTA to Experience

### DIFF
--- a/sections.jsx
+++ b/sections.jsx
@@ -20,7 +20,7 @@ function Hero() {
             <span className="meta-item"><span className="meta-label">Loc</span> {data.meta.location}</span>
           </div>
           <div className="hero-cta">
-            <a className="btn btn-primary" href="#projects">See projects <span className="btn-arrow">→</span></a>
+            <a className="btn btn-primary" href="#experience">View experience <span className="btn-arrow">→</span></a>
             <a className="btn btn-ghost" href={`mailto:${data.meta.email}`}>Get in touch</a>
           </div>
         </div>

--- a/styles.css
+++ b/styles.css
@@ -1720,9 +1720,12 @@ a { color: inherit; text-decoration: none; }
   .theme-toggle { width: 34px; height: 34px; font-size: 14px; }
 }
 @media (max-width: 640px) {
-  /* Nav — wrap into 2 rows: brand + theme on row 1, nav-links on row 2 */
-  .nav { padding: calc(env(safe-area-inset-top, 0px) + 10px) max(16px, env(safe-area-inset-right, 0px)) 10px max(16px, env(safe-area-inset-left, 0px)); flex-wrap: wrap; row-gap: 6px; }
-  .nav.scrolled { padding: calc(env(safe-area-inset-top, 0px) + 8px) max(16px, env(safe-area-inset-right, 0px)) 8px max(16px, env(safe-area-inset-left, 0px)); }
+  /* Nav — wrap into 2 rows: brand + theme on row 1, nav-links on row 2.
+     Padding-top has a 40px floor so the nav clears typical phone status bars
+     even when env(safe-area-inset-top) returns 0 (e.g. Mi Browser, older
+     Chromiums that don't honor viewport-fit=cover). */
+  .nav { padding: max(calc(env(safe-area-inset-top, 0px) + 10px), 40px) max(16px, env(safe-area-inset-right, 0px)) 10px max(16px, env(safe-area-inset-left, 0px)); flex-wrap: wrap; row-gap: 6px; }
+  .nav.scrolled { padding: max(calc(env(safe-area-inset-top, 0px) + 8px), 36px) max(16px, env(safe-area-inset-right, 0px)) 8px max(16px, env(safe-area-inset-left, 0px)); }
   .nav-brand { order: 1; gap: 6px; }
   .theme-toggle { order: 2; width: 34px; height: 34px; font-size: 14px; }
   .nav-links {


### PR DESCRIPTION
## Summary
Two follow-ups on top of #17:

**1. Mobile nav looking cramped under the status bar on Android phones.**
PR #17 added `viewport-fit=cover` and `padding-top: calc(env(safe-area-inset-top, 0px) + Npx)`. That works on devices that draw the page edge-to-edge behind the status bar (where `env()` reports the actual inset). But on most Android browsers in portrait — Samsung Internet / Chrome on Samsung Galaxy, etc. — the WebView is rendered *below* the status bar by default, so `env(safe-area-inset-top)` correctly returns `0px` and the nav had only the bare `10px` of breathing room. The brand and theme toggle ended up sitting right against the status-bar icons.

Wrap the mobile (`<=640px`) padding-top in `max(calc(env(safe-area-inset-top, 0px) + 10px), 40px)` so there is always at least a 40px gap. Browsers that *do* honor `env()` (notched iPhones in edge-to-edge, etc.) still pick up the larger of the two values.

**2. Swap the primary hero CTA from "See projects" → "View experience"** pointing to `#experience` instead of `#projects`.

## Test plan
- [ ] Phone with status bar (Samsung Galaxy etc.): brand + theme toggle have clear breathing room (no cramping)
- [ ] iPhone notched / edge-to-edge: brand still clears the notch (env-derived value used when larger than 40px)
- [ ] Desktop: nav padding unchanged at 18px
- [ ] Hero primary button reads "View experience →" and scrolls to the Experience section
- [ ] Get-in-touch button still opens mailto

🤖 Generated with [Claude Code](https://claude.com/claude-code)