### PR TITLE
fix: tighten mobile nav top padding and clear hero behind nav

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1721,11 +1721,11 @@ a { color: inherit; text-decoration: none; }
 }
 @media (max-width: 640px) {
   /* Nav — wrap into 2 rows: brand + theme on row 1, nav-links on row 2.
-     Padding-top has a 40px floor so the nav clears typical phone status bars
-     even when env(safe-area-inset-top) returns 0 (e.g. Mi Browser, older
-     Chromiums that don't honor viewport-fit=cover). */
-  .nav { padding: max(calc(env(safe-area-inset-top, 0px) + 10px), 40px) max(16px, env(safe-area-inset-right, 0px)) 10px max(16px, env(safe-area-inset-left, 0px)); flex-wrap: wrap; row-gap: 6px; }
-  .nav.scrolled { padding: max(calc(env(safe-area-inset-top, 0px) + 8px), 36px) max(16px, env(safe-area-inset-right, 0px)) 8px max(16px, env(safe-area-inset-left, 0px)); }
+     Padding-top has a 28px floor so the nav clears typical phone status bars
+     even when env(safe-area-inset-top) returns 0; on edge-to-edge / notched
+     devices env() reports the actual inset and the larger of the two wins. */
+  .nav { padding: max(calc(env(safe-area-inset-top, 0px) + 6px), 28px) max(16px, env(safe-area-inset-right, 0px)) 10px max(16px, env(safe-area-inset-left, 0px)); flex-wrap: wrap; row-gap: 6px; }
+  .nav.scrolled { padding: max(calc(env(safe-area-inset-top, 0px) + 4px), 24px) max(16px, env(safe-area-inset-right, 0px)) 8px max(16px, env(safe-area-inset-left, 0px)); }
   .nav-brand { order: 1; gap: 6px; }
   .theme-toggle { order: 2; width: 34px; height: 34px; font-size: 14px; }
   .nav-links {
@@ -1744,7 +1744,7 @@ a { color: inherit; text-decoration: none; }
 
   /* Sections — tighter padding */
   .section { padding: 48px 18px; }
-  .hero { padding-top: 96px; padding-bottom: 40px; min-height: auto; }
+  .hero { padding-top: max(calc(env(safe-area-inset-top, 0px) + 110px), 130px); padding-bottom: 40px; min-height: auto; }
   .section-header { margin-bottom: 32px; gap: 12px; flex-wrap: wrap; }
 
   /* Hero typography scales further down */


### PR DESCRIPTION
## Summary
PR #18's `40px` padding-top floor on the mobile nav was too generous, and the resulting nav (~110px tall after the brand row + gap + nav-links) ate into the hero — which only had `96px` of top padding — so the second nav row visibly overlapped the "Sujay Kumar Suman." heading.

**Two adjustments:**
- Drop the mobile nav padding-top floor from `40px` → `28px` (and the scrolled-state floor from `36px` → `24px`). Still clears typical phone status bars, but feels far less heavy on Galaxy / Samsung-style devices where `env(safe-area-inset-top)` already returns 0 in portrait. On edge-to-edge / notched devices `env()` reports the actual inset and `max()` still picks the larger value.
- Bump the mobile (`<=640px`) hero padding-top from `96px` → `max(calc(env(safe-area-inset-top, 0px) + 110px), 130px)` so the heading clears the nav with ~20-25px of breathing room regardless of which arm of the max wins.

## Test plan
- [ ] Mobile (Galaxy S25 Ultra): brand and theme toggle have a tighter, less-airy gap above (was ~40px floor, now 28px)
- [ ] Hero "Sujay Kumar Suman." no longer overlaps the nav-links row
- [ ] Notched iPhone: nav still pushed below the inset (env() value preferred when larger)
- [ ] Desktop: nav (18px) and hero (120px) padding unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)